### PR TITLE
add missing name in tunable()

### DIFF
--- a/R/step_select_aov.R
+++ b/R/step_select_aov.R
@@ -204,7 +204,7 @@ tidy.step_select_aov <- function(x, ...) {
 #' @export
 tunable.step_select_aov <- function(x, ...) {
   tibble::tibble(
-    name = c("top_p", "threshold"),
+    name = c("top_p", "threshold", "cutoff"),
     call_info = list(
       list(pkg = "colino", fun = "top_p"),
       list(pkg = "dials", fun = "threshold", range = c(-10, -1)),

--- a/R/step_select_carscore.R
+++ b/R/step_select_carscore.R
@@ -231,7 +231,7 @@ tidy.step_select_carscore <- function(x, type = "terms", ...) {
 #' @export
 tunable.step_select_carscore <- function(x, ...) {
   tibble::tibble(
-    name = c("top_p", "threshold"),
+    name = c("top_p", "threshold", "cutoff"),
     call_info = list(
       list(pkg = "colino", fun = "top_p"),
       list(pkg = "dials", fun = "threshold", range = c(0, 1)),

--- a/R/step_select_forests.R
+++ b/R/step_select_forests.R
@@ -245,7 +245,7 @@ tidy.step_select_forests <- function(x, type = "terms", ...) {
 #' @export
 tunable.step_select_forests <- function(x, ...) {
   tibble(
-    name = c("top_p", "threshold", "mtry", "trees", "min_n"),
+    name = c("top_p", "threshold", "cutoff", "mtry", "trees", "min_n"),
     call_info = list(
       list(pkg = "colino", fun = "top_p"),
       list(pkg = "dials", fun = "threshold", range = c(0, 1)),

--- a/R/step_select_infgain.R
+++ b/R/step_select_infgain.R
@@ -240,7 +240,7 @@ tidy.step_select_infgain <- function(x, type = "terms", ...) {
 #' @export
 tunable.step_select_infgain <- function(x, ...) {
   tibble::tibble(
-    name = c("top_p", "threshold"),
+    name = c("top_p", "entropy", "threshold", "cutoff"),
     call_info = list(
       list(pkg = "colino", fun = "top_p"),
       list(pkg = "colino", fun = "entropy", values = values_entropy),

--- a/R/step_select_linear.R
+++ b/R/step_select_linear.R
@@ -257,7 +257,7 @@ tidy.step_select_linear <- function(x, type = "terms", ...) {
 #' @export
 tunable.step_select_linear <- function(x, ...) {
   tibble(
-    name = c("top_p", "threshold", "penalty", "mixture"),
+    name = c("top_p", "threshold", "cutoff", "penalty", "mixture"),
     call_info = list(
       list(pkg = "colino", fun = "top_p"),
       list(pkg = "dials", fun = "threshold", range = c(0, 1)),

--- a/R/step_select_mrmr.R
+++ b/R/step_select_mrmr.R
@@ -214,7 +214,7 @@ tidy.step_select_mrmr <- function(x, type = "terms", ...) {
 #' @export
 tunable.step_select_mrmr <- function(x, ...) {
   tibble(
-    name = c("top_p", "threshold"),
+    name = c("top_p", "threshold", "cutoff"),
     call_info = list(
       list(pkg = "colino", fun = "top_p"),
       list(pkg = "dials", fun = "threshold", range = c(0, 1)),

--- a/R/step_select_relief.R
+++ b/R/step_select_relief.R
@@ -244,7 +244,7 @@ tidy.step_select_relief <- function(x, ...) {
 #' @export
 tunable.step_select_relief <- function(x, ...) {
   tibble::tibble(
-    name = c("top_p", "threshold"),
+    name = c("top_p", "threshold", "cutoff"),
     call_info = list(
       list(pkg = "colino", fun = "top_p"),
       list(pkg = "dials", fun = "threshold", range = c(0, 1)),

--- a/R/step_select_roc.R
+++ b/R/step_select_roc.R
@@ -208,7 +208,7 @@ tidy.step_select_roc <- function(x, ...) {
 #' @export
 tunable.step_select_roc <- function(x, ...) {
   tibble::tibble(
-    name = c("top_p", "threshold"),
+    name = c("top_p", "threshold", "cutoff"),
     call_info = list(
       list(pkg = "colino", fun = "top_p"),
       list(pkg = "dials", fun = "threshold", range = c(0, 1)),

--- a/R/step_select_tree.R
+++ b/R/step_select_tree.R
@@ -245,7 +245,7 @@ tidy.step_select_tree <- function(x, type = "terms", ...) {
 #' @export
 tunable.step_select_tree <- function(x, ...) {
   tibble(
-    name = c("top_p", "threshold", "cost_complexity", "tree_depth", "min_n"),
+    name = c("top_p", "threshold", "cutoff", "cost_complexity", "tree_depth", "min_n"),
     call_info = list(
       list(pkg = "colino", fun = "top_p"),
       list(pkg = "dials", fun = "threshold", range = c(0, 1)),

--- a/R/step_select_vip.R
+++ b/R/step_select_vip.R
@@ -216,7 +216,7 @@ tidy.step_select_vip <- function(x, type = "terms", ...) {
 #' @export
 tunable.step_select_vip <- function(x, ...) {
   tibble(
-    name = c("top_p", "threshold"),
+    name = c("top_p", "threshold", "cutoff"),
     call_info = list(
       list(pkg = "colino", fun = "top_p"),
       list(pkg = "dials", fun = "threshold", range = c(0, 1)),

--- a/R/step_select_xtab.R
+++ b/R/step_select_xtab.R
@@ -209,7 +209,7 @@ tidy.step_select_xtab <- function(x, ...) {
 #' @export
 tunable.step_select_xtab <- function(x, ...) {
   tibble::tibble(
-    name = c("top_p", "threshold"),
+    name = c("top_p", "threshold", "cutoff"),
     call_info = list(
       list(pkg = "colino", fun = "top_p"),
       list(pkg = "dials", fun = "threshold", range = c(-10, -1)),


### PR DESCRIPTION
In https://github.com/stevenpawley/colino/commit/b6f15487029eaabf6a147383d290104d35cd4854, when you added `cutoff`, you correctly added it to the `tunable.step_*()` functions under the `call_info`, but you forgot to add it in the `name` field.

This PR should fix that!