### PR TITLE
allow `aorsf`  engine in `step_select_forests`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,4 +51,6 @@ Suggests:
     care,
     modeldata,
     covr,
-    FSinR
+    FSinR,
+    bonsai,
+    aorsf

--- a/R/pull_importances.R
+++ b/R/pull_importances.R
@@ -151,6 +151,37 @@ pull_importances._ranger <- function(object, scaled = TRUE, ...) {
 }
 
 #' @export
+pull_importances._ObliqueForestClassification <- function(object, scaled = TRUE, ...) {
+  pull_importance_aorsf(object, scaled, ...)
+}
+
+#' @export
+pull_importances._ObliqueForestRegression <- function(object, scaled = TRUE, ...) {
+  pull_importance_aorsf(object, scaled, ...)
+}
+
+#' @export
+pull_importances._ObliqueForestSurvival <- function(object, scaled = TRUE, ...) {
+  pull_importance_aorsf(object, scaled, ...)
+}
+
+pull_importance_aorsf <- function(object, scaled, ...){
+
+  call <- rlang::call2(.fn = "orsf_vi", .ns = "aorsf", object = object$fit)
+
+  scores <- rlang::eval_tidy(call)
+
+  scores <- tibble(feature = names(scores), importance = as.numeric(scores))
+
+  if (scaled)
+    scores$importance <- rescale(scores$importance)
+
+  scores
+
+}
+
+
+#' @export
 pull_importances._cubist <- function(object, scaled = TRUE, ...) {
   scores <- object$fit$usage
 

--- a/R/step_select_forests.R
+++ b/R/step_select_forests.R
@@ -89,10 +89,19 @@ step_select_forests <- function(
 
   engines <- parsnip::show_engines("rand_forest")$engine
 
-  if (!engine %in% parsnip::show_engines("rand_forest")$engine)
+  if (!engine %in% parsnip::show_engines("rand_forest")$engine){
+
+    # make message more clear if someone is trying to use aorsf
+    if(engine == 'aorsf'){
+      rlang::abort("the bonsai package must be loaded to use aorsf engine")
+    }
+
     rlang::abort(
       paste("Engine argument should be one of", paste(engines, collapse = ", "))
     )
+
+  }
+
 
   recipes::add_step(
     recipe,
@@ -167,6 +176,11 @@ prep.step_select_forests <- function(x, training, info = NULL, ...) {
       mtry = x$mtry,
       min_n = x$min_n
     )
+
+    # aorsf package uses 'permute' instead of 'permutation'
+    if(x$engine == 'aorsf' & x$options$importance == 'permutation'){
+      x$options$importance <- 'permute'
+    }
 
     model_spec <-
       parsnip::make_call("rand_forest", args = model_args, ns = "parsnip")

--- a/tests/testthat/test_step_select_forests.R
+++ b/tests/testthat/test_step_select_forests.R
@@ -60,3 +60,48 @@ test_that("step_select_forests, execution using threshold", {
   expect_length(names(selected), 2)
 })
 
+test_that(
+  desc = "step_select_forests, execution using aorsf",
+  code = {
+
+    skip_if_not_installed('aorsf')
+    skip_if_not_installed('bonsai')
+
+    library(bonsai)
+
+    irisX <- iris[-5]
+    y <- iris$Species
+
+    # test selection by retaining features with scores >= 50th percentile
+    rec <- iris %>%
+      recipe(Species ~.) %>%
+      step_select_forests(
+        all_predictors(),
+        outcome = "Species",
+        threshold = 0.5,
+        engine = 'aorsf'
+      )
+
+    prepped <- prep(rec)
+    selected <- juice(prepped)
+
+    expect_length(names(selected), 3)
+
+    # test selection by retaining features with scores in 90th percentile
+    rec <- iris %>%
+      recipe(Species ~.) %>%
+      step_select_forests(
+        all_predictors(),
+        outcome = "Species",
+        threshold = 0.9
+      )
+
+    prepped <- prep(rec)
+    selected <- juice(prepped)
+
+    expect_length(names(selected), 2)
+
+  }
+)
+
+


### PR DESCRIPTION
fixes #12 

In an attempt to be unintrusive, I didn't change very much. I think it's a little awkward having to add three methods for `pull_importance`, but it works. I did this because the `parsnip` fit has a mode specific class for the `aorsf` models. 